### PR TITLE
support quick copy to clipboard

### DIFF
--- a/template.html
+++ b/template.html
@@ -72,6 +72,21 @@ __MARKDOWN__
   marked.setOptions({ renderer: new Renderer() });
   document.getElementById('CONTENT').innerHTML = marked.parse(document.getElementById('MARKDOWN').innerText);
   marked.defaults.renderer.postActions.forEach(fn => fn());
+
+
+  // quick copy tooltip to clipboard
+  let tooltipElement = document.getElementById("railroad-tooltip");
+  for (const span of document.querySelectorAll('.non-terminal')) {
+    span.addEventListener("click", () => {
+      // skip spans without tooltip
+      if (tooltipElement.style.display !== 'block') {
+        return;
+      }
+      navigator.clipboard.writeText(tooltipElement.innerText).then(() => {
+        alert("Copy tooltip to clipboard");
+      });
+    }) 
+  }
 </script>
 
 </body>


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

It's annoying when I try to copy the tooltip content, so I add click copy to spans with tooltip, just click and get the tooltip content.

<img width="476" alt="image" src="https://user-images.githubusercontent.com/9587680/177523470-f0304616-70ec-4101-afa4-993ae9538379.png">
