### PR TITLE
Add the critical path of TiDB write

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -2,6 +2,7 @@
 
 - [TiDB Query Duration](tidb-query-duration)
 - [TiDB Read Query](tidb-read-query)
+- [TiDB Write Query](tidb-write-query)
 - [TiDB Snapshot Read](tidb-snapshot-read)
 - [TiDB KV Client](tidb-kv-client)
 - [TiKV](tikv)

--- a/src/tidb-kv-client.md
+++ b/src/tidb-kv-client.md
@@ -89,10 +89,10 @@ Diagram(
       Choice(
         0,
         Comment("use 2pc or causal consistency"),
-        Span("Get min-commit-ts"),
+        Span("Get min-commit-ts", {color: "blue", tooltip: "Get_latest_ts_time"}),
       ),
       Optional("Async prewrite binlog", "skip"),
-      Span("Prewrite mutations", {href: "#do-action-on-mutations"}),
+      Span("Prewrite mutations", {href: "#do-action-on-mutations", color: "blue", tooltip: "Prewrite_time"}),
       Optional("Wait prewrite binlog result", "skip"),
     ),
     Sequence(
@@ -101,9 +101,9 @@ Diagram(
         Comment("1pc"),
         Sequence(
           Comment("2pc"),
-          Span("Get commit-ts"),
+          Span("Get commit-ts", {color: "blue", tooltip: "Get_commit_ts_time"}),
           Span("Check schema (try to amend if needed)"),
-          Span("Commit mutations", {href: "#do-action-on-mutations"}),
+          Span("Commit PK mutation", {href: "#do-action-on-mutations", color: "blue", tooltip: "Commit_time"}),
         ),
         Sequence(
           Comment("async-commit"),
@@ -122,6 +122,11 @@ Diagram(
 ```
 
 - Spans are recorded in `CommitDetails` which can be extracted from slow log.
+- The duration of commit protocol can be observed in slowlog.
+  - Get min-commit-ts is observed as `Get_latest_ts_time`.
+  - Prewrite mutations duration is observed as `Prewrite_time`.
+  - Get commit-ts is observed as `Get_commit_ts_time`.
+  - Commit PK mutation duration is observed as `Commit_time`.
 
 ## Txn KV: Rollback
 
@@ -177,6 +182,9 @@ Diagram(
   ),
 )
 ```
+
+- The average batch size can be calculate from `sum(rate(tidb_tikvclient_txn_regions_num_sum)) / sum(rate(tidb_tikvclient_txn_regions_num_count))`.
+- The default concurrency of batch executor is `128`, so we can take latency amplification of batch executor as `sum(rate(tidb_tikvclient_txn_regions_num_sum)) / sum(rate(tidb_tikvclient_txn_regions_num_count)) / 128`.
 
 ### Action: Pessimistic Lock
 

--- a/src/tidb-read-query.md
+++ b/src/tidb-read-query.md
@@ -13,10 +13,10 @@ Diagram(
   ),
   Choice(
     0,
-    Span("Read handle by index key", {href: "tidb-snapshot-read#get"}),
+    Span("Read handle by index key", {color: "green", href: "tidb-snapshot-read#get", tooltip: "tidb_tikvclient_txn_cmd_duration_seconds{type=\"get\"}"}),
     Comment("Read by clustered PK, encode handle by key"),
   ),
-  Span("Read value by handle", {href: "tidb-snapshot-read#get"}),
+  Span("Read value by handle", {color: "green", href: "tidb-snapshot-read#get", tooltip: "tidb_tikvclient_txn_cmd_duration_seconds{type=\"get\"}"}),
 )
 ```
 
@@ -27,10 +27,10 @@ Diagram(
   Span("Resolve TSO", {href: "tidb-kv-client#resolve-tso"}),
   Choice(
     0,
-    Span("Read all handles by index keys", {href: "tidb-snapshot-read#batchget"}),
+    Span("Read all handles by index keys", {color: "green", href: "tidb-snapshot-read#batchget", tooltip: "tidb_tikvclient_txn_cmd_duration_seconds{type=\"batch_get\"}"}),
     Comment("Read by clustered PK, encode handle by keys"),
   ),
-  Span("Read values by handles", {href: "tidb-snapshot-read#batchget"}),
+  Span("Read values by handles", {color: "green", href: "tidb-snapshot-read#batchget", tooltip: "tidb_tikvclient_txn_cmd_duration_seconds{type=\"batch_get\"}"}),
 )
 ```
 

--- a/src/tidb-snapshot-read.md
+++ b/src/tidb-snapshot-read.md
@@ -25,6 +25,8 @@ Diagram(
 )
 ```
 
+- The duration is observed as `tidb_tikvclient_txn_cmd_duration_seconds{type="get"}`.
+
 ## BatchGet
 
 ```railroad
@@ -55,6 +57,8 @@ Diagram(
   )
 )
 ```
+
+- The duration is observed as `tidb_tikvclient_txn_cmd_duration_seconds{type="batch_get"}`.
 
 ## Coprocessor Scan
 

--- a/src/tidb-write-query.md
+++ b/src/tidb-write-query.md
@@ -1,0 +1,112 @@
+# TiDB Write Duration
+
+TiDB process write queries in a no-delay way, and many write executors are based upon read executors.
+
+```railroad
+Diagram(
+  Span("Execute write query"),
+  Choice(
+    0,
+    Span("Pessimistic lock keys", {href: "tidb-kv-client#txn-kv-lock-keys"}),
+    Comment("bypass in optimistic transaction")
+  ),
+  Choice(
+    0,
+    Span("Auto Commit Transaction"),
+    Comment("bypass in non-auto-commit or explicit transaction")
+  ),
+)
+```
+
+## Insert
+
+```railroad
+Diagram(
+  OneOrMore(
+    Sequence(
+      Choice(
+        0,
+        Span("Check key exist", {href: "tidb-snapshot-read#get"}),
+        Comment("Skip check for optimistic transaction")
+      ),
+      Span("Insert into membuffer")
+    ),
+    Comment("Loop insert rows")
+  )
+)
+```
+
+TiDB processes insert in memory so it's fast for small dataset.
+With large dataset like `insert into select`, the insert is processed only in a single thread(about 50,000 to 100,000 rows per second), there may be a performance issue.
+
+## Delete
+
+```railroad
+Diagram(
+  Span("Read data", {href: "tidb-read-query"}),
+  OneOrMore(
+    Span("Delete from membuffer"),
+    Comment("Loop delete keys"),
+  )
+)
+```
+
+Similar with insert, delete are fast for small dataset.
+With large dataset, delete is little faster than insert statement.
+
+## Update
+
+```railroad
+Diagram(
+  Span("Read data", {href: "tidb-read-query"}),
+  OneOrMore(
+    Sequence(
+      Span("Check key exist", {href: "tidb-snapshot-read#get"}),
+      Span("Insert into membuffer")
+    ),
+    Comment("Loop update rows")
+  )
+)
+```
+
+Update combines delete and insert.
+
+## Cursor Read
+
+Cursor read(`select for update`) is a special type of read statement, it's processed the same way like non-cursor read statements in optimistic and auto-commit transactions. Only inside pessimistic transactions, cursor read have an extra pessimistic lock phase.
+Cursor read with coprocessor executors add pessimisitc locks in the same way of write executors, so we analyze point get and batch point get here.
+
+### Cursor Point Get
+
+```railroad
+Diagram(
+  Choice(
+    0,
+    Sequence(
+      Span("Read handle key by index key"),
+      Span("Lock index key", {href: "tidb-kv-client#txn-kv-lock-keys"})
+    ),
+    Comment("Clustered index")
+  ),
+  Span("Lock handle key", {href: "tidb-kv-client#txn-kv-lock-keys"}),
+  Span("Raed value from pessimistic lock cache")
+)
+```
+
+### Cursor Batch Point Get
+
+```railroad
+Diagram(
+  Choice(
+    0,
+    Sequence(
+      Span("Read handle keys by index keys"),
+    ),
+    Comment("Clustered index")
+  ),
+  Span("Lock index and handle keys", {href: "tidb-kv-client#txn-kv-lock-keys"}),
+  Span("Raed values from pessimistic lock cache")
+)
+```
+
+Cursor point get and batch point get read data from pessimistic lock cache which means pessimistic lock is responsed with the locked value of that key.

--- a/src/tidb-write-query.md
+++ b/src/tidb-write-query.md
@@ -7,12 +7,12 @@ Diagram(
   Span("Execute write query"),
   Choice(
     0,
-    Span("Pessimistic lock keys", {href: "tidb-kv-client#txn-kv-lock-keys"}),
+    Span("Pessimistic lock keys", {color: "green", href: "tidb-kv-client#txn-kv-lock-keys", tooltip: "tidb_tikvclient_txn_cmd_duration_seconds{type=\"lock_keys\"}"}),
     Comment("bypass in optimistic transaction")
   ),
   Choice(
     0,
-    Span("Auto Commit Transaction"),
+    Span("Auto Commit Transaction", {color: "green", href: "tidb-kv-client#txn-kv-commit", tooltip: "tidb_tikvclient_txn_cmd_duration_seconds{type=\"commit\"}"}),
     Comment("bypass in non-auto-commit or explicit transaction")
   ),
 )
@@ -23,14 +23,7 @@ Diagram(
 ```railroad
 Diagram(
   OneOrMore(
-    Sequence(
-      Choice(
-        0,
-        Span("Check key exist", {href: "tidb-snapshot-read#get"}),
-        Comment("Skip check for optimistic transaction")
-      ),
-      Span("Insert into membuffer")
-    ),
+    Span("Insert into membuffer"),
     Comment("Loop insert rows")
   )
 )
@@ -83,12 +76,12 @@ Diagram(
   Choice(
     0,
     Sequence(
-      Span("Read handle key by index key"),
-      Span("Lock index key", {href: "tidb-kv-client#txn-kv-lock-keys"})
+      Span("Read handle key by index key", {color: "green", href: "tidb-snapshot-read#get", tooltip: "tidb_tikvclient_txn_cmd_duration_seconds{type=\"get\"}"}),
+      Span("Lock index key", {color: "green", href: "tidb-kv-client#txn-kv-lock-keys", tooltip: "tidb_tikvclient_txn_cmd_duration_seconds{type=\"lock_keys\"}"})
     ),
     Comment("Clustered index")
   ),
-  Span("Lock handle key", {href: "tidb-kv-client#txn-kv-lock-keys"}),
+  Span("Lock handle key", {color: "green", href: "tidb-kv-client#txn-kv-lock-keys", tooltip: "tidb_tikvclient_txn_cmd_duration_seconds{type=\"lock_keys\"}"}),
   Span("Raed value from pessimistic lock cache")
 )
 ```
@@ -100,13 +93,13 @@ Diagram(
   Choice(
     0,
     Sequence(
-      Span("Read handle keys by index keys"),
+      Span("Read handle keys by index keys", {color: "green", href: "tidb-snapshot-read#batchget", tooltip: "tidb_tikvclient_txn_cmd_duration_seconds{type=\"batch_get\"}"}),
     ),
     Comment("Clustered index")
   ),
-  Span("Lock index and handle keys", {href: "tidb-kv-client#txn-kv-lock-keys"}),
+  Span("Lock index and handle keys", {color: "green", href: "tidb-kv-client#txn-kv-lock-keys", tooltip: "tidb_tikvclient_txn_cmd_duration_seconds{type=\"lock_keys\"}"}),
   Span("Raed values from pessimistic lock cache")
 )
 ```
 
-Cursor point get and batch point get read data from pessimistic lock cache which means pessimistic lock is responsed with the locked value of that key.
+Cursor point get and batch point get acquire pessimistic locks the locked values, so they can read data from pessimistic lock cache directly later.

--- a/src/tikv.md
+++ b/src/tikv.md
@@ -114,6 +114,7 @@ Diagram(
   Choice(
     0,
     Span("Async Write"),
+    Comment("in-mem pessimistic lock")
   ),
   Span("Grpc Response"),
 )
@@ -122,6 +123,7 @@ Diagram(
 - The latch acquisition is observed as `TiKV_scheduler_latch_wait_duration_seconds{type=xxx}`.
 - The write command processing may needs to read related from engine first.
 - The async write stage includes both transaction log consistency and state machine apply, it's observed as `tikv_storage_engine_async_request_duration_seconds{type=write}`.
+- In-mem pessimistic lock will bypass write phase, the in-mem lock count is observed as `tikv_in_memory_pessimistic_locking{result="success"}`.
 
 ### TxnKV Async Write
 

--- a/template.html
+++ b/template.html
@@ -17,6 +17,9 @@ __TITLE__
   svg.railroad-diagram g.color-yellow rect {
     fill: rgb(254, 255, 204);
   }
+  svg.railroad-diagram g.color-blue rect {
+    fill: rgb(202, 220, 250);
+  }
   *:target {
     background-color: rgb(247, 226, 198);
   }


### PR DESCRIPTION
- Add the critical path of TiDB write
- Mark slow log items as blue blocks